### PR TITLE
#15 Retain both pre- and post-merge results

### DIFF
--- a/src/main/java/io/beanmapper/spring/web/MergePair.java
+++ b/src/main/java/io/beanmapper/spring/web/MergePair.java
@@ -1,0 +1,70 @@
+package io.beanmapper.spring.web;
+
+import io.beanmapper.BeanMapper;
+
+public class MergePair<T> {
+
+    private T beforeMerge;
+    private T afterMerge;
+    private final BeanMapper beanMapper;
+    private final EntityFinder entityFinder;
+    private final Class<?> entityClass;
+    private final MergedForm annotation;
+
+    public MergePair(BeanMapper beanMapper, EntityFinder entityFinder, Class<?> entityClass, MergedForm annotation) {
+        this.beanMapper = beanMapper;
+        this.entityFinder = entityFinder;
+        this.entityClass = entityClass;
+        this.annotation = annotation;
+    }
+
+    public void initNew(Object source) {
+        setAfterMerge(beanMapper.map(source, targetEntityClass()));
+    }
+
+    public void merge(BeanMapper customBeanMapper, Object source, Long id) {
+        T target = (T)findSource(id);
+        setAfterMerge(customBeanMapper.map(source, target));
+    }
+
+    public T getBeforeMerge() {
+        return beforeMerge;
+    }
+
+    public T getAfterMerge() {
+        return afterMerge;
+    }
+
+    public Object result() {
+        return isMergePair() ? this : getAfterMerge();
+    }
+
+    private void createBeforeMerge(Object source) {
+        setBeforeMerge(beanMapper.map(source, targetEntityClass()));
+    }
+
+    private Object findSource(Long id) {
+        Object entity = entityFinder.find(id, targetEntityClass());
+        if (isMergePair()) {
+            createBeforeMerge(entity);
+        }
+        return entity;
+    }
+
+    private boolean isMergePair() {
+        return entityClass.equals(MergePair.class);
+    }
+
+    private Class<T> targetEntityClass() {
+        return isMergePair() ? (Class<T>)annotation.mergePairClass() : (Class<T>)entityClass;
+    }
+
+    private void setBeforeMerge(T beforeMerge) {
+        this.beforeMerge = beforeMerge;
+    }
+
+    private void setAfterMerge(T afterMerge) {
+        this.afterMerge = afterMerge;
+    }
+
+}

--- a/src/main/java/io/beanmapper/spring/web/MergedForm.java
+++ b/src/main/java/io/beanmapper/spring/web/MergedForm.java
@@ -38,4 +38,9 @@ public @interface MergedForm {
      */
     String mergeId() default "";
 
+    /**
+     * Class types of the before-/afterMerge instances maintained in MergePair
+     */
+    Class<?> mergePairClass() default Object.class;
+
 }

--- a/src/test/java/io/beanmapper/spring/web/PersonController.java
+++ b/src/test/java/io/beanmapper/spring/web/PersonController.java
@@ -46,4 +46,10 @@ public class PersonController {
         return person.get();
     }
 
+    @RequestMapping(value = "/{id}/pair", method = RequestMethod.PUT)
+    @ResponseBody
+    public MergePair<Person> updateReturnPair(@MergedForm(value = PersonForm.class, mergeId = "id", mergePairClass = Person.class) MergePair personPair) {
+        return personPair;
+    }
+
 }

--- a/src/test/java/io/beanmapper/spring/web/PersonControllerTest.java
+++ b/src/test/java/io/beanmapper/spring/web/PersonControllerTest.java
@@ -138,4 +138,34 @@ public class PersonControllerTest extends AbstractSpringTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("Jan"));
     }
 
+    @Test
+    public void testPair() throws Exception {
+        Person person = new Person();
+        person.setName("Henk");
+        person.setCity("Leiden");
+        person.setStreet("Stationsplein");
+        person.setHouseNumber("42");
+        person.setBankAccount("1234567890");
+        personRepository.save(person);
+
+        this.webClient.perform(MockMvcRequestBuilders.put("/person/" + person.getId() + "/pair")
+                .content("{\"name\":\"Jan\",\"city\":\"Delft\"}")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.beforeMerge.id").value(person.getId().intValue()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.beforeMerge.name").value("Henk"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.beforeMerge.street").value("Stationsplein"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.beforeMerge.city").value("Leiden"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.beforeMerge.houseNumber").value("42"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.beforeMerge.bankAccount").value("1234567890"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.afterMerge.id").value(person.getId().intValue()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.afterMerge.name").value("Jan"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.afterMerge.street").value("Stationsplein"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.afterMerge.city").value("Delft"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.afterMerge.houseNumber").value("42"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.afterMerge.bankAccount").value("1234567890"));
+
+    }
+
 }


### PR DESCRIPTION
The class is used when @MergedForm is applied. Instead of the target class, put the MergePair there. The handler will use this instruction together with @MergedForm.mergePairClass to retain both the pre-merged instance (copied using BeanMapper) and the merged instance. The information can be used by other processes to determine the differences before and after the merge.