### PR TITLE
#16 @MergedForm can deal with multipart forms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,12 @@
             <version>4.3.1.Final</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Logging -->
         <dependency>

--- a/src/main/java/io/beanmapper/spring/web/MergedForm.java
+++ b/src/main/java/io/beanmapper/spring/web/MergedForm.java
@@ -43,4 +43,10 @@ public @interface MergedForm {
      */
     Class<?> mergePairClass() default Object.class;
 
+    /**
+     * The name of the request part in the multipart form
+     * @return the name of the request part in the multipart form
+     */
+    String multiPart() default "";
+
 }

--- a/src/test/java/io/beanmapper/spring/web/PersonController.java
+++ b/src/test/java/io/beanmapper/spring/web/PersonController.java
@@ -3,6 +3,8 @@
  */
 package io.beanmapper.spring.web;
 
+import javax.validation.Valid;
+
 import io.beanmapper.spring.Lazy;
 import io.beanmapper.spring.model.Person;
 import io.beanmapper.spring.model.PersonForm;
@@ -10,7 +12,9 @@ import io.beanmapper.spring.model.PersonForm;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.multipart.MultipartFile;
 
 @Controller
 @RequestMapping("/person")
@@ -44,6 +48,14 @@ public class PersonController {
     @ResponseBody
     public Person updateLazy(@MergedForm(value = PersonForm.class, mergeId = "id") Lazy<Person> person) {
         return person.get();
+    }
+
+    @RequestMapping(value = "/{id}/multipart", method = RequestMethod.POST)
+    @ResponseBody
+    public Person updateForMultipart(
+            @Valid @MergedForm(value = PersonForm.class, mergeId = "id", multiPart = "person") Person person,
+            @RequestPart(value = "photo", required = false) MultipartFile photo) {
+        return person;
     }
 
     @RequestMapping(value = "/{id}/pair", method = RequestMethod.PUT)


### PR DESCRIPTION
if the @MergedForm annotation contains the argument multiPart, its handler will switch to retrieving the JSON from a multi-part form request. The handler that does the heavy lifting is Spring's own RequestPartMethodArgumentResolver. To make use of this powertool, MethodParameter needed to be hacked to ensure it uses the form class, not the entity class.