### PR TITLE
Spring handles multipart forms differently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue [#19](https://github.com/42BV/beanmapper-spring/issues/19), **Spring handles multipart forms differently**; v4.1.6 deal with the multipart form by getting the parameterType as the target class. Later Spring versions (at least from 4.3.10.RELEASE onwards), do this by checking the genericParameterType. The solution is to check for the genericParameterType. If it exists, it is overwritten for the multipart form resolution attempt.
 
 ## [2.0.0] - 2017-10-12
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,9 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <junit.version>4.10</junit.version>
+        <junit.version>4.12</junit.version>
         <slf4j.version>1.7.2</slf4j.version>
-        <spring.version>4.1.6.RELEASE</spring.version>
+        <spring.version>4.3.10.RELEASE</spring.version>
         <spring.jpa.version>1.8.0.RELEASE</spring.jpa.version>
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <!-- Reporting -->
@@ -142,14 +142,14 @@
         </dependency>
         <dependency>
             <groupId>junit</groupId>
-            <artifactId>junit-dep</artifactId>
+            <artifactId>junit</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>0.9.0</version>
+            <version>2.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/beanmapper/spring/web/MergedFormMethodArgumentResolver.java
+++ b/src/main/java/io/beanmapper/spring/web/MergedFormMethodArgumentResolver.java
@@ -12,6 +12,8 @@ import io.beanmapper.BeanMapper;
 import io.beanmapper.spring.Lazy;
 import io.beanmapper.spring.web.converter.StructuredBody;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.Conventions;
 import org.springframework.core.MethodParameter;
@@ -29,6 +31,8 @@ import org.springframework.web.servlet.mvc.method.annotation.AbstractMessageConv
 import org.springframework.web.servlet.mvc.method.annotation.RequestPartMethodArgumentResolver;
 
 public class MergedFormMethodArgumentResolver extends AbstractMessageConverterMethodArgumentResolver {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final BeanMapper beanMapper;
 
@@ -101,6 +105,13 @@ public class MergedFormMethodArgumentResolver extends AbstractMessageConverterMe
         Field f1 = formParameter.getClass().getDeclaredField("parameterType");
         f1.setAccessible(true);
         f1.set(formParameter, annotation.value());
+        try {
+            Field f2 = formParameter.getClass().getDeclaredField("genericParameterType");
+            f2.setAccessible(true);
+            f2.set(formParameter, annotation.value());
+        } catch (NoSuchFieldException err) {
+            logger.warn("Older Spring version? Update to at least 4.3.10.RELEASE, see https://github.com/42BV/beanmapper-spring/issues/19");
+        }
         return multiPartResolver.resolveArgument(formParameter, mavContainer, webRequest, binderFactory);
     }
 

--- a/src/main/java/io/beanmapper/spring/web/mockmvc/MockMvcBeanMapper.java
+++ b/src/main/java/io/beanmapper/spring/web/mockmvc/MockMvcBeanMapper.java
@@ -28,7 +28,7 @@ public class MockMvcBeanMapper {
         this.beanMapper = beanMapper.config().build();
     }
 
-    public void registerRepository(CrudRepository<? extends Persistable, Long> repository, Class<?> entityClass) {
+    public <T extends Persistable> void registerRepository(CrudRepository<T, Long> repository, Class<T> entityClass) {
 
         // Add a converter for the target class to the generic conversion service
         conversionService.addConverter(String.class, entityClass, new MockEntityConverter<>(repository));

--- a/src/test/java/io/beanmapper/spring/web/PersonControllerTest.java
+++ b/src/test/java/io/beanmapper/spring/web/PersonControllerTest.java
@@ -3,7 +3,10 @@
  */
 package io.beanmapper.spring.web;
 
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
 
 import io.beanmapper.BeanMapper;
 import io.beanmapper.config.BeanMapperBuilder;
@@ -12,8 +15,6 @@ import io.beanmapper.spring.ApplicationConfig;
 import io.beanmapper.spring.model.Person;
 import io.beanmapper.spring.model.PersonRepository;
 import io.beanmapper.spring.web.converter.StructuredJsonMessageConverter;
-
-import java.util.Arrays;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
@@ -72,7 +73,7 @@ public class PersonControllerTest extends AbstractSpringTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("Henk"));
+                .andExpect(jsonPath("$.name").value("Henk"));
     }
 
     @Test
@@ -87,9 +88,9 @@ public class PersonControllerTest extends AbstractSpringTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(person.getId().intValue()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("Jan"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.city").value("Lisse"));
+                .andExpect(jsonPath("$.id").value(person.getId().intValue()))
+                .andExpect(jsonPath("$.name").value("Jan"))
+                .andExpect(jsonPath("$.city").value("Lisse"));
     }
     
     @Test
@@ -103,10 +104,10 @@ public class PersonControllerTest extends AbstractSpringTest {
                 .content("{\"name\":\"Jan\"}")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(person.getId().intValue()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("Jan"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.city").doesNotExist());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(person.getId().intValue()))
+                .andExpect(jsonPath("$.name").value("Jan"))
+                .andExpect(jsonPath("$.city").doesNotExist());
     }
     
     @Test
@@ -122,9 +123,9 @@ public class PersonControllerTest extends AbstractSpringTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(person.getId().intValue()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("Jan"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.city").doesNotExist());
+                .andExpect(jsonPath("$.id").value(person.getId().intValue()))
+                .andExpect(jsonPath("$.name").value("Jan"))
+                .andExpect(jsonPath("$.city").doesNotExist());
     }
 
     @Test
@@ -138,8 +139,8 @@ public class PersonControllerTest extends AbstractSpringTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(person.getId().intValue()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("Jan"));
+                .andExpect(jsonPath("$.id").value(person.getId().intValue()))
+                .andExpect(jsonPath("$.name").value("Jan"));
     }
 
     @Test
@@ -160,9 +161,9 @@ public class PersonControllerTest extends AbstractSpringTest {
                         .file(photoPart)
                 )
                 .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(person.getId().intValue()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("Jan"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.street").value("Stationsplein"));
+                .andExpect(jsonPath("$.id").value(person.getId().intValue()))
+                .andExpect(jsonPath("$.name").value("Jan"))
+                .andExpect(jsonPath("$.street").value("Stationsplein"));
     }
 
     @Test
@@ -180,18 +181,18 @@ public class PersonControllerTest extends AbstractSpringTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.beforeMerge.id").value(person.getId().intValue()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.beforeMerge.name").value("Henk"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.beforeMerge.street").value("Stationsplein"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.beforeMerge.city").value("Leiden"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.beforeMerge.houseNumber").value("42"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.beforeMerge.bankAccount").value("1234567890"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.afterMerge.id").value(person.getId().intValue()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.afterMerge.name").value("Jan"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.afterMerge.street").value("Stationsplein"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.afterMerge.city").value("Delft"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.afterMerge.houseNumber").value("42"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.afterMerge.bankAccount").value("1234567890"));
+                .andExpect(jsonPath("$.beforeMerge.id").value(person.getId().intValue()))
+                .andExpect(jsonPath("$.beforeMerge.name").value("Henk"))
+                .andExpect(jsonPath("$.beforeMerge.street").value("Stationsplein"))
+                .andExpect(jsonPath("$.beforeMerge.city").value("Leiden"))
+                .andExpect(jsonPath("$.beforeMerge.houseNumber").value("42"))
+                .andExpect(jsonPath("$.beforeMerge.bankAccount").value("1234567890"))
+                .andExpect(jsonPath("$.afterMerge.id").value(person.getId().intValue()))
+                .andExpect(jsonPath("$.afterMerge.name").value("Jan"))
+                .andExpect(jsonPath("$.afterMerge.street").value("Stationsplein"))
+                .andExpect(jsonPath("$.afterMerge.city").value("Delft"))
+                .andExpect(jsonPath("$.afterMerge.houseNumber").value("42"))
+                .andExpect(jsonPath("$.afterMerge.bankAccount").value("1234567890"));
 
     }
 

--- a/src/test/java/io/beanmapper/spring/web/mockmvc/AbstractControllerTest.java
+++ b/src/test/java/io/beanmapper/spring/web/mockmvc/AbstractControllerTest.java
@@ -38,7 +38,7 @@ public class AbstractControllerTest {
         return mockMvcBeanMapper.getBeanMapper();
     }
 
-    public void registerRepository(CrudRepository<? extends Persistable, Long> repository, Class<?> entityClass) {
+    public <T extends Persistable> void registerRepository(CrudRepository<T, Long> repository, Class<T> entityClass) {
         mockMvcBeanMapper.registerRepository(repository, entityClass);
     }
 }


### PR DESCRIPTION
v4.1.6 deal with the multipart form by getting the parameterType as the target class. Later Spring versions (at least from 4.3.10.RELEASE onwards), do this by checking the genericParameterType. The solution is to check for the genericParameterType. If it exists, it is overwritten for the multipart form resolution attempt.