### PR TITLE
Multipart part name not used correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue [#21](https://github.com/42BV/beanmapper-spring/issues/21), **Multipart part name not used correctly**; the multipart part name was not handled correctly. Spring's multipart handler is now passed a MethodParameter which has the correct part name and also disable the parameter name explorer, so it is forced to used the overwritten part name.
 
 ## [2.0.1] - 2017-10-18
 ### Fixed

--- a/src/main/java/io/beanmapper/spring/web/MergedFormMethodArgumentResolver.java
+++ b/src/main/java/io/beanmapper/spring/web/MergedFormMethodArgumentResolver.java
@@ -102,17 +102,21 @@ public class MergedFormMethodArgumentResolver extends AbstractMessageConverterMe
             NativeWebRequest webRequest, WebDataBinderFactory binderFactory,
             MergedForm annotation) throws Exception {
         MethodParameter formParameter = new MethodParameter(parameter);
-        Field f1 = formParameter.getClass().getDeclaredField("parameterType");
-        f1.setAccessible(true);
-        f1.set(formParameter, annotation.value());
+        setMethodParameterField(formParameter, "parameterType", annotation.value());
+        setMethodParameterField(formParameter, "genericParameterType", annotation.value());
+        setMethodParameterField(formParameter, "parameterName", annotation.multiPart());
+        setMethodParameterField(formParameter, "parameterNameDiscoverer", null);
+        return multiPartResolver.resolveArgument(formParameter, mavContainer, webRequest, binderFactory);
+    }
+
+    private void setMethodParameterField(MethodParameter formParameter, String fieldName, Object value) throws IllegalAccessException {
         try {
-            Field f2 = formParameter.getClass().getDeclaredField("genericParameterType");
-            f2.setAccessible(true);
-            f2.set(formParameter, annotation.value());
+            Field f = formParameter.getClass().getDeclaredField(fieldName);
+            f.setAccessible(true);
+            f.set(formParameter, value);
         } catch (NoSuchFieldException err) {
             logger.warn("Older Spring version? Update to at least 4.3.10.RELEASE, see https://github.com/42BV/beanmapper-spring/issues/19");
         }
-        return multiPartResolver.resolveArgument(formParameter, mavContainer, webRequest, binderFactory);
     }
 
     private void validateObject(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory, Object objectToValidate) throws Exception {

--- a/src/test/java/io/beanmapper/spring/web/PersonController.java
+++ b/src/test/java/io/beanmapper/spring/web/PersonController.java
@@ -53,7 +53,7 @@ public class PersonController {
     @RequestMapping(value = "/{id}/multipart", method = RequestMethod.POST)
     @ResponseBody
     public Person updateForMultipart(
-            @Valid @MergedForm(value = PersonForm.class, mergeId = "id", multiPart = "person") Person person,
+            @Valid @MergedForm(value = PersonForm.class, mergeId = "id", multiPart = "personForm") Person person,
             @RequestPart(value = "photo", required = false) MultipartFile photo) {
         return person;
     }

--- a/src/test/java/io/beanmapper/spring/web/PersonControllerTest.java
+++ b/src/test/java/io/beanmapper/spring/web/PersonControllerTest.java
@@ -152,7 +152,7 @@ public class PersonControllerTest extends AbstractSpringTest {
 
         byte[] bytes = IOUtils.toByteArray("CAFEBABE");
         MockMultipartFile photoPart = new MockMultipartFile("photo", "photo.jpeg", "image/jpeg", bytes);
-        MockMultipartFile personPart = new MockMultipartFile("person", "", "application/json", "{\"name\":\"Jan\"}".getBytes());
+        MockMultipartFile personPart = new MockMultipartFile("personForm", "", "application/json", "{\"name\":\"Jan\"}".getBytes());
 
         webClient.perform(
                     MockMvcRequestBuilders


### PR DESCRIPTION
Issue #21, the multipart part name was not handled correctly. Spring's multipart handler is now passed a MethodParameter which has the correct part name and also disable the parameter name explorer, so it is forced to used the overwritten part name.