### PR TITLE
Added a JPA-specific AfterClearFlusher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper-spring</artifactId>
-    <version>2.0.2</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>42 Bean Mapper Spring Support</name>
     <description>Spring support for the Bean Mapper</description>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.beanmapper</groupId>
             <artifactId>beanmapper</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/io/beanmapper/spring/flusher/JpaAfterClearFlusher.java
+++ b/src/main/java/io/beanmapper/spring/flusher/JpaAfterClearFlusher.java
@@ -1,0 +1,24 @@
+package io.beanmapper.spring.flusher;
+
+import javax.persistence.EntityManager;
+
+import io.beanmapper.config.AfterClearFlusher;
+
+/**
+ * Specific AfterClearFlusher for flushing JPA's EntityManager. This is called by
+ * BeanMapper after calling clear on a collection.
+ */
+public class JpaAfterClearFlusher implements AfterClearFlusher {
+
+    private final EntityManager entityManager;
+
+    public JpaAfterClearFlusher(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Override
+    public void flush() {
+        entityManager.flush();
+    }
+
+}

--- a/src/test/java/io/beanmapper/spring/flusher/CollSource.java
+++ b/src/test/java/io/beanmapper/spring/flusher/CollSource.java
@@ -1,0 +1,13 @@
+package io.beanmapper.spring.flusher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.beanmapper.annotations.BeanCollection;
+
+public class CollSource {
+
+    @BeanCollection(elementType = CollTarget.class, flushAfterClear = true)
+    public List<String> items = new ArrayList<>();
+
+}

--- a/src/test/java/io/beanmapper/spring/flusher/CollTarget.java
+++ b/src/test/java/io/beanmapper/spring/flusher/CollTarget.java
@@ -1,0 +1,10 @@
+package io.beanmapper.spring.flusher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CollTarget {
+
+    public List<String> items = new ArrayList<>();
+
+}

--- a/src/test/java/io/beanmapper/spring/flusher/JpaAfterClearFlusherTest.java
+++ b/src/test/java/io/beanmapper/spring/flusher/JpaAfterClearFlusherTest.java
@@ -1,0 +1,35 @@
+package io.beanmapper.spring.flusher;
+
+import javax.persistence.EntityManager;
+
+import io.beanmapper.BeanMapper;
+import io.beanmapper.config.BeanMapperBuilder;
+import mockit.Mocked;
+import mockit.StrictExpectations;
+
+import org.junit.Test;
+
+public class JpaAfterClearFlusherTest {
+
+    @Mocked
+    private EntityManager entityManager;
+
+    @Test
+    public void persistenceManagerFlushCalled() {
+        new StrictExpectations(){{
+            entityManager.flush();
+        }};
+        JpaAfterClearFlusher flusher = new JpaAfterClearFlusher(entityManager);
+        CollSource source = new CollSource() {{
+            items.add("A");
+        }};
+        CollTarget target = new CollTarget() {{
+            items.add("B");
+        }};
+        BeanMapper beanMapper = new BeanMapperBuilder()
+                .addAfterClearFlusher(flusher)
+                .build();
+        beanMapper.map(source, target);
+    }
+
+}

--- a/src/test/java/io/beanmapper/spring/model/Person.java
+++ b/src/test/java/io/beanmapper/spring/model/Person.java
@@ -1,6 +1,15 @@
 package io.beanmapper.spring.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 
 @Entity
 public class Person extends BaseEntity {
@@ -14,6 +23,12 @@ public class Person extends BaseEntity {
     private String city;
 
     private String bankAccount;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "owner_tag")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tag")
+    private List<Tag> tags = new ArrayList<>();
 
     public String getName() {
         return name;
@@ -53,5 +68,13 @@ public class Person extends BaseEntity {
 
     public void setBankAccount(String bankAccount) {
         this.bankAccount = bankAccount;
+    }
+
+    public List<Tag> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<Tag> tags) {
+        this.tags = tags;
     }
 }

--- a/src/test/java/io/beanmapper/spring/model/PersonForm.java
+++ b/src/test/java/io/beanmapper/spring/model/PersonForm.java
@@ -1,9 +1,16 @@
 package io.beanmapper.spring.model;
 
+import java.util.List;
+
+import io.beanmapper.annotations.BeanCollection;
+
 public class PersonForm {
     
     public String name;
     
     public String city;
+
+    @BeanCollection(elementType = Tag.class)
+    public List<String> tags;
 
 }

--- a/src/test/java/io/beanmapper/spring/model/Tag.java
+++ b/src/test/java/io/beanmapper/spring/model/Tag.java
@@ -1,0 +1,7 @@
+package io.beanmapper.spring.model;
+
+public enum Tag {
+    CUSTOMER,
+    DEBTOR,
+    UPSELLING
+}


### PR DESCRIPTION
Issue #24 prepare a JPA-specific flusher that must be registered by the Spring Boot starter. This flusher makes sure the EntityManager.flush gets called after a clear.

Also added in tests that are required later on for a refactoring of the mechanism BeanMapper uses to deal with collections.