### PR TITLE
Validations for the entity are not run for Lazy targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **BREAKING CHANGE** Issue [#26](https://github.com/42BV/beanmapper-spring/issues/26), **Validations for the entity are not run for Lazy targets**; the @MergedForm maps to a Lazy object, it delays the process of mapping until the time that get() is called on the Lazy object. At that time, it should work exactly the same way as a regular validation run. Forms are always validated right away. However, the final objects are only validated when direct mapping takes place. The process has been refactored so that validation on the final target is included in the delayed mapping process. Note that Lazy.get() must now deal with Exception. The pro of this approach is that it hooks onto the regular binding result handler. 
 
 ## [2.1.0] - 2017-10-25
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper-spring</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>42 Bean Mapper Spring Support</name>
     <description>Spring support for the Bean Mapper</description>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.beanmapper</groupId>
             <artifactId>beanmapper</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/io/beanmapper/spring/Lazy.java
+++ b/src/main/java/io/beanmapper/spring/Lazy.java
@@ -15,6 +15,6 @@ public interface Lazy<T> {
      * Retrieve the entity instance.
      * @return the entity instance
      */
-    T get();
+    T get() throws Exception;
 
 }

--- a/src/main/java/io/beanmapper/spring/web/WebRequestParameters.java
+++ b/src/main/java/io/beanmapper/spring/web/WebRequestParameters.java
@@ -1,0 +1,40 @@
+package io.beanmapper.spring.web;
+
+import org.springframework.core.Conventions;
+import org.springframework.core.MethodParameter;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class WebRequestParameters {
+
+    private final MethodParameter parameter;
+    private final ModelAndViewContainer mavContainer;
+    private final NativeWebRequest webRequest;
+    private final WebDataBinderFactory binderFactory;
+
+    public WebRequestParameters(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) {
+        this.parameter = parameter;
+        this.mavContainer = mavContainer;
+        this.webRequest = webRequest;
+        this.binderFactory = binderFactory;
+    }
+
+    public WebDataBinder createBinder(Object objectToValidate) throws Exception {
+        String name = Conventions.getVariableNameForParameter(parameter);
+        return binderFactory.createBinder(webRequest, objectToValidate, name);
+    }
+
+    public void setBindingResult(BindingResult bindingResult) {
+        String name = Conventions.getVariableNameForParameter(parameter);
+        mavContainer.addAttribute(BindingResult.MODEL_KEY_PREFIX + name, bindingResult);
+    }
+
+    public MethodParameter getParameter() {
+        return parameter;
+    }
+
+}

--- a/src/test/java/io/beanmapper/spring/model/Person.java
+++ b/src/test/java/io/beanmapper/spring/model/Person.java
@@ -10,10 +10,12 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
+import javax.validation.constraints.NotNull;
 
 @Entity
 public class Person extends BaseEntity {
 
+    @NotNull
     private String name;
 
     private String street;

--- a/src/test/java/io/beanmapper/spring/web/PersonController.java
+++ b/src/test/java/io/beanmapper/spring/web/PersonController.java
@@ -46,7 +46,7 @@ public class PersonController {
 
     @RequestMapping(value = "/{id}/lazy", method = RequestMethod.PUT)
     @ResponseBody
-    public Person updateLazy(@MergedForm(value = PersonForm.class, mergeId = "id") Lazy<Person> person) {
+    public Person updateLazy(@Valid @MergedForm(value = PersonForm.class, mergeId = "id") Lazy<Person> person) throws Exception {
         return person.get();
     }
 

--- a/src/test/java/io/beanmapper/spring/web/PersonControllerTest.java
+++ b/src/test/java/io/beanmapper/spring/web/PersonControllerTest.java
@@ -32,7 +32,6 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -75,7 +74,7 @@ public class PersonControllerTest extends AbstractSpringTest {
                 .content("{\"name\":\"Henk\"}")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("Henk"));
     }
 
@@ -90,7 +89,7 @@ public class PersonControllerTest extends AbstractSpringTest {
                 .content("{\"name\":\"Jan\"}")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(person.getId().intValue()))
                 .andExpect(jsonPath("$.name").value("Jan"))
                 .andExpect(jsonPath("$.city").value("Lisse"));
@@ -125,7 +124,7 @@ public class PersonControllerTest extends AbstractSpringTest {
                 .content("{\"name\":\"Jan\"}")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(person.getId().intValue()))
                 .andExpect(jsonPath("$.name").value("Jan"))
                 .andExpect(jsonPath("$.city").doesNotExist());
@@ -141,9 +140,22 @@ public class PersonControllerTest extends AbstractSpringTest {
                 .content("{\"name\":\"Jan\"}")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(person.getId().intValue()))
                 .andExpect(jsonPath("$.name").value("Jan"));
+    }
+
+    @Test
+    public void testLazyFailFinalValidation() throws Exception {
+        Person person = new Person();
+        person.setName("Henk");
+        personRepository.save(person);
+
+        this.webClient.perform(MockMvcRequestBuilders.put("/person/" + person.getId() + "/lazy")
+                .content("{}")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().is4xxClientError());
     }
 
     @Test
@@ -206,7 +218,7 @@ public class PersonControllerTest extends AbstractSpringTest {
                 .content("{\"name\":\"Jan\",\"city\":\"Delft\"}")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.beforeMerge.id").value(person.getId().intValue()))
                 .andExpect(jsonPath("$.beforeMerge.name").value("Henk"))
                 .andExpect(jsonPath("$.beforeMerge.street").value("Stationsplein"))
@@ -239,7 +251,7 @@ public class PersonControllerTest extends AbstractSpringTest {
                 .content("{\"name\":\"Jan\",\"city\":\"Lisse\",\"tags\":[\"CUSTOMER\",\"DEBTOR\"]}")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.beforeMerge.id").value(person.getId().intValue()))
                 .andExpect(jsonPath("$.beforeMerge.tags[0]").value("UPSELLING"))
                 .andExpect(jsonPath("$.afterMerge.id").value(person.getId().intValue()))


### PR DESCRIPTION
Issue #26. If the @MergedForm maps to a Lazy object, it delays the process of mapping until the time that get() is called on the Lazy object. At that time, it should work exactly the same way as a regular validation run. Forms are always validated right away. However, the final objects are only validated when direct mapping takes place. The process has been refactored so that validation on the final target is included in the delayed mapping process. Note that Lazy.get() must now deal with Exception. The pro of this approach is that it hooks onto the regular binding result handler.