### PR TITLE
Made beanmapper-spring compatible with Spring 5:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,24 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <beanmapper.version>2.4.1</beanmapper.version>
+        <commons.io.version>2.6</commons.io.version>
+        <el.api.version>3.0.0</el.api.version>
+        <el.impl.version>2.2</el.impl.version>
+        <guava.version>25.1-jre</guava.version>
+        <hibernate.version>5.3.1.Final</hibernate.version>
+        <hsqldb.version>2.4.1</hsqldb.version>
+        <jackson.databind.version>2.9.6</jackson.databind.version>
+        <javax.validation.api.version>2.0.1.Final</javax.validation.api.version>
+        <javax.servlet.version>4.0.1</javax.servlet.version>
+        <jmockit.version>1.17</jmockit.version>
+        <jsonpath.version>2.4.0</jsonpath.version>
         <junit.version>4.12</junit.version>
         <slf4j.version>1.7.2</slf4j.version>
-        <spring.version>4.3.10.RELEASE</spring.version>
-        <spring.jpa.version>1.8.0.RELEASE</spring.jpa.version>
-        <javax.servlet.version>3.1.0</javax.servlet.version>
+        <spring.version>5.0.7.RELEASE</spring.version>
+        <spring.security.config.version>5.0.6.RELEASE</spring.security.config.version>
+        <spring.jpa.version>2.0.8.RELEASE</spring.jpa.version>
+
         <!-- Reporting -->
         <maven.cobertura.version>2.5.2</maven.cobertura.version>
         <maven.javadoc.version>2.8</maven.javadoc.version>
@@ -70,12 +83,12 @@
         <dependency>
             <groupId>io.beanmapper</groupId>
             <artifactId>beanmapper</artifactId>
-            <version>2.4.1</version>
+            <version>${beanmapper.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0-rc1</version>
+            <version>${guava.version}</version>
         </dependency>
 
         <!-- Spring integration -->
@@ -94,7 +107,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
-            <version>4.2.4.RELEASE</version>
+            <version>${spring.security.config.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -114,7 +127,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
-            <version>4.3.8.Final</version>
+            <version>${hibernate.version}</version>
             <scope>provided</scope>
         </dependency>
         
@@ -130,7 +143,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.5.2</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         
         <!-- Used for unit testing -->
@@ -143,7 +156,7 @@
         <dependency>
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
-            <version>1.17</version>
+            <version>${jmockit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -155,31 +168,46 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.2.0</version>
+            <version>${jsonpath.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.3.2</version>
+            <version>${hsqldb.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Bean validation -->
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-            <version>1.0.0.GA</version>
+            <version>${javax.validation.api.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>4.3.1.Final</version>
+            <version>${hibernate.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>javax.el-api</artifactId>
+            <version>${el.api.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>el-impl</artifactId>
+            <version>${el.impl.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>${commons.io.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/io/beanmapper/spring/PageableMapper.java
+++ b/src/main/java/io/beanmapper/spring/PageableMapper.java
@@ -38,7 +38,7 @@ public class PageableMapper {
         } else {
             transformed = Collections.emptyList();
         }
-        Pageable pageable = new PageRequest(source.getNumber(), source.getSize(), source.getSort());
+        Pageable pageable = PageRequest.of(source.getNumber(), source.getSize(), source.getSort());
         return new PageImpl<T>(transformed, pageable, source.getTotalElements());
     }
 

--- a/src/main/java/io/beanmapper/spring/converter/IdToEntityBeanConverter.java
+++ b/src/main/java/io/beanmapper/spring/converter/IdToEntityBeanConverter.java
@@ -2,6 +2,8 @@ package io.beanmapper.spring.converter;
 
 import java.io.Serializable;
 
+import javax.persistence.EntityNotFoundException;
+
 import io.beanmapper.BeanMapper;
 import io.beanmapper.core.BeanFieldMatch;
 import io.beanmapper.core.converter.BeanConverter;
@@ -25,8 +27,11 @@ public class IdToEntityBeanConverter implements BeanConverter {
             return null;
         }
 
-        CrudRepository repository = (CrudRepository) repositories.getRepositoryFor(targetClass);
-        return repository.findOne((Serializable) source);
+        CrudRepository repository = (CrudRepository) repositories.getRepositoryFor(targetClass).orElseThrow(() -> new EntityNotFoundException(
+                "No repository found for " + targetClass.getName()
+        ));
+
+        return repository.findById(source).orElse(null);
     }
 
     /**

--- a/src/main/java/io/beanmapper/spring/web/MergePair.java
+++ b/src/main/java/io/beanmapper/spring/web/MergePair.java
@@ -40,7 +40,7 @@ public class MergePair<T> {
     }
 
     private void createBeforeMerge(Object source) {
-        setBeforeMerge(beanMapper.wrapConfig().build().map(source, targetEntityClass()));
+        setBeforeMerge(beanMapper.wrap().build().map(source, targetEntityClass()));
     }
 
     private Object findSource(Long id) {

--- a/src/main/java/io/beanmapper/spring/web/MergedFormMethodArgumentResolver.java
+++ b/src/main/java/io/beanmapper/spring/web/MergedFormMethodArgumentResolver.java
@@ -169,7 +169,7 @@ public class MergedFormMethodArgumentResolver extends AbstractMessageConverterMe
         Set<String> propertyNames = getPropertyNames(form);
 
         // Modify the BeanMapper to deal with special situations
-        BeanMapperBuilder customBeanMapperBuilder = beanMapper.wrapConfig();
+        BeanMapperBuilder customBeanMapperBuilder = beanMapper.wrap();
         if (annotation.patch() && propertyNames != null) {
             customBeanMapperBuilder.downsizeSource(new ArrayList<>(propertyNames));
         }

--- a/src/main/java/io/beanmapper/spring/web/SpringDataEntityFinder.java
+++ b/src/main/java/io/beanmapper/spring/web/SpringDataEntityFinder.java
@@ -25,17 +25,13 @@ public class SpringDataEntityFinder implements EntityFinder {
     @Override
     @SuppressWarnings("unchecked")
     public Object find(Long id, Class<?> entityClass) throws EntityNotFoundException {
-        CrudRepository<?, Long> repository = (CrudRepository<?, Long>) repositories.getRepositoryFor(entityClass);
-        if (repository == null) {
-            throw new EntityNotFoundException(
-                    "No repository found for " + entityClass.getName());
-        }
-        Object entity = repository.findOne(id);
-        if (entity == null) {
-            throw new EntityNotFoundException(
-                    "Entity with ID " + id + "was not found in repository " + repository.getClass().getName());
-        }
-        return entity;
+        CrudRepository<?, Long> repository = (CrudRepository<?, Long>) repositories.getRepositoryFor(entityClass).orElseThrow(() -> new EntityNotFoundException(
+                "No repository found for " + entityClass.getName())
+        );
+
+        return repository.findById(id).orElseThrow(() -> new EntityNotFoundException(
+                        "Entity with ID " + id + "was not found in repository " + repository.getClass().getName())
+        );
     }
 
 }

--- a/src/main/java/io/beanmapper/spring/web/mockmvc/MockEntityConverter.java
+++ b/src/main/java/io/beanmapper/spring/web/mockmvc/MockEntityConverter.java
@@ -14,7 +14,7 @@ public class MockEntityConverter<T extends Persistable> implements Converter<Str
 
     @Override
     public T convert(String id) {
-        return repository.findOne(Long.valueOf(id));
+        return repository.findById(Long.valueOf(id)).orElse(null);
     }
 
 }

--- a/src/main/java/io/beanmapper/spring/web/mockmvc/MockEntityFinder.java
+++ b/src/main/java/io/beanmapper/spring/web/mockmvc/MockEntityFinder.java
@@ -21,7 +21,7 @@ public class MockEntityFinder implements EntityFinder {
             throw new RuntimeException("No constructor found for " + entityClass.getSimpleName() +
                     ". Make sure to register the class in addConverters.registerExpectation");
         }
-        return repository.findOne(id);
+        return repository.findById(id).orElse(null);
     }
 
     public void addRepository(CrudRepository<? extends Persistable, Long> repository, Class<?> entityClass) {

--- a/src/main/java/io/beanmapper/spring/web/mockmvc/MockIdToEntityBeanConverter.java
+++ b/src/main/java/io/beanmapper/spring/web/mockmvc/MockIdToEntityBeanConverter.java
@@ -20,7 +20,7 @@ public class MockIdToEntityBeanConverter implements BeanConverter {
 
     @Override
     public Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
-        return repository.findOne((Long)source);
+        return repository.findById((Long)source).orElse(null);
     }
 
     @Override

--- a/src/main/java/io/beanmapper/spring/web/mockmvc/MockMvcBeanMapper.java
+++ b/src/main/java/io/beanmapper/spring/web/mockmvc/MockMvcBeanMapper.java
@@ -26,7 +26,7 @@ public class MockMvcBeanMapper {
                              BeanMapper beanMapper) {
         this.conversionService = conversionService;
         this.messageConverters = messageConverters;
-        this.beanMapper = beanMapper.config().build();
+        this.beanMapper = beanMapper.wrap().build();
     }
 
     public <T extends Persistable> void registerRepository(CrudRepository<T, Long> repository, Class<T> entityClass) {
@@ -35,7 +35,7 @@ public class MockMvcBeanMapper {
         conversionService.addConverter(String.class, entityClass, new MockEntityConverter<>(repository));
 
         // Add a BeanConverter for the target class to the BeanMapper
-        beanMapper = beanMapper.config().addConverter(new MockIdToEntityBeanConverter(repository, entityClass)).build();
+        beanMapper = beanMapper.wrap().addConverter(new MockIdToEntityBeanConverter(repository, entityClass)).build();
 
         // Add the repository to the MockEntityFinder
         mockEntityFinder.addRepository(repository, entityClass);

--- a/src/test/java/io/beanmapper/spring/AbstractSpringTest.java
+++ b/src/test/java/io/beanmapper/spring/AbstractSpringTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 /**
@@ -18,7 +18,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
  * @since Aug 24, 2015
  */
 @WebAppConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
 @ContextConfiguration(classes = { ApplicationConfig.class })
 public abstract class AbstractSpringTest {
     

--- a/src/test/java/io/beanmapper/spring/PageableMapperTest.java
+++ b/src/test/java/io/beanmapper/spring/PageableMapperTest.java
@@ -20,7 +20,7 @@ import org.springframework.data.domain.Sort;
 
 public class PageableMapperTest {
     
-    private final Pageable pageable = new PageRequest(0, 10, new Sort("id"));
+    private final Pageable pageable = PageRequest.of(0, 10, Sort.by("id"));
 
     private BeanMapper beanMapper;
 

--- a/src/test/java/io/beanmapper/spring/web/EntityFinderTest.java
+++ b/src/test/java/io/beanmapper/spring/web/EntityFinderTest.java
@@ -28,7 +28,7 @@ public class EntityFinderTest extends AbstractSpringTest {
 
             @Override
             public Object find(Long id, Class<?> entityClass) throws EntityNotFoundException {
-                return personRepository.findOne(id);
+                return personRepository.findById(id).orElse(null);
             }
 
         };

--- a/src/test/java/io/beanmapper/spring/web/PersonControllerTest.java
+++ b/src/test/java/io/beanmapper/spring/web/PersonControllerTest.java
@@ -23,9 +23,7 @@ import io.beanmapper.spring.web.converter.StructuredJsonMessageConverter;
 import mockit.Mocked;
 import mockit.StrictExpectations;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -209,13 +207,13 @@ public class PersonControllerTest extends AbstractSpringTest {
         person.setStreet("Stationsplein");
         personRepository.save(person);
 
-        byte[] bytes = IOUtils.toByteArray("CAFEBABE");
+        byte[] bytes = "CAFEBABE".getBytes();
         MockMultipartFile photoPart = new MockMultipartFile("photo", "photo.jpeg", "image/jpeg", bytes);
         MockMultipartFile personPart = new MockMultipartFile("personForm", "", "application/json", "{\"name\":\"Jan\"}".getBytes());
 
         webClient.perform(
                     MockMvcRequestBuilders
-                        .fileUpload("/person/" + person.getId() + "/multipart")
+                        .multipart("/person/" + person.getId() + "/multipart")
                         .file(personPart)
                         .file(photoPart)
                 )

--- a/src/test/java/io/beanmapper/spring/web/mockmvc/ContainingFakeControllerTest.java
+++ b/src/test/java/io/beanmapper/spring/web/mockmvc/ContainingFakeControllerTest.java
@@ -1,5 +1,7 @@
 package io.beanmapper.spring.web.mockmvc;
 
+import java.util.Optional;
+
 import io.beanmapper.spring.web.mockmvc.fakedomain.ContainingFake;
 import io.beanmapper.spring.web.mockmvc.fakedomain.ContainingFakeController;
 import io.beanmapper.spring.web.mockmvc.fakedomain.ContainingFakeForm;
@@ -50,8 +52,8 @@ public class ContainingFakeControllerTest extends AbstractControllerTest {
     @Test
     public void create() throws Exception {
         new Expectations(){{
-            fakeRepository.findOne(42L);
-            result = fake;
+            fakeRepository.findById(42L);
+            result = Optional.ofNullable(fake);
 
             containingFakeService.create((ContainingFake) any);
             result = containingFake;
@@ -83,8 +85,8 @@ public class ContainingFakeControllerTest extends AbstractControllerTest {
     @Test
     public void createThrowsValidationExceptionForMappedTarget() throws Exception {
         new Expectations(){{
-            fakeRepository.findOne(42L);
-            result = fake;
+            fakeRepository.findById(42L);
+            result = Optional.ofNullable(fake);
         }};
 
         ContainingFakeForm containingFakeForm = new ContainingFakeForm();

--- a/src/test/java/io/beanmapper/spring/web/mockmvc/FakeControllerTest.java
+++ b/src/test/java/io/beanmapper/spring/web/mockmvc/FakeControllerTest.java
@@ -1,5 +1,7 @@
 package io.beanmapper.spring.web.mockmvc;
 
+import java.util.Optional;
+
 import io.beanmapper.spring.web.mockmvc.fakedomain.Fake;
 import io.beanmapper.spring.web.mockmvc.fakedomain.FakeController;
 import io.beanmapper.spring.web.mockmvc.fakedomain.FakeForm;
@@ -42,8 +44,8 @@ public class FakeControllerTest extends AbstractControllerTest {
         fake.setName("Henk");
 
         new NonStrictExpectations() {{
-            fakeRepository.findOne(42L);
-            result = fake;
+            fakeRepository.findById(42L);
+            result = Optional.ofNullable(fake);
         }};
 
     }

--- a/src/test/java/io/beanmapper/spring/web/mockmvc/fakedomain/FakeWebMvcConfig.java
+++ b/src/test/java/io/beanmapper/spring/web/mockmvc/fakedomain/FakeWebMvcConfig.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.Version;
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 @ComponentScan(basePackageClasses = FakeApplicationConfig.class,
         includeFilters = @ComponentScan.Filter({ ControllerAdvice.class, Controller.class, RestController.class }),
         excludeFilters = @ComponentScan.Filter({ Configuration.class, Service.class, Repository.class }))
-public class FakeWebMvcConfig extends WebMvcConfigurerAdapter {
+public class FakeWebMvcConfig implements WebMvcConfigurer {
 
     @Autowired
     private FormattingConversionService mvcConversionService;


### PR DESCRIPTION
- Compatible with new repositories returning Optionals
- Changed deprecated new PageRequest() to PageRequest.of()
- Added Expression Language (EL) api and implementation (test scope) to enable testing Bean Validations in Spring 5
- Updated most dependencies to their latest versions.
- Replaced all other deprecated method calls with up-to-date calls