### PR TITLE
#32 MergePair.beforeMerge must be untouched, not BeanMapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Version upgrade
+- Full upgrade to **Spring 5 / Spring Boot 2**. This version of BeanMapper Spring is no longer usable with lower versions.
+- Issue [#32](https://github.com/42BV/beanmapper-spring/issues/32); **MergePair.beforeMerge must be untouched, not BeanMapped** when a MergePair is used, the ```beforeMerge``` is now retrieved and immediately detached before the target is fetched. Take note that this means that the original's proxies can no longer be resolved. This restriction does not apply to the target.
 
 ## [2.4.1] - 2018-06-20
 ### Version upgrade

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper-spring</artifactId>
-    <version>2.4.2.SPRING5-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>42 Bean Mapper Spring Support</name>
     <description>Spring support for the Bean Mapper</description>
@@ -56,7 +56,7 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <beanmapper.version>2.4.1</beanmapper.version>
+        <beanmapper.version>3.0.0</beanmapper.version>
         <commons.io.version>2.6</commons.io.version>
         <el.api.version>3.0.0</el.api.version>
         <el.impl.version>2.2</el.impl.version>

--- a/src/main/java/io/beanmapper/spring/converter/ConversionServiceBeanConverter.java
+++ b/src/main/java/io/beanmapper/spring/converter/ConversionServiceBeanConverter.java
@@ -4,7 +4,7 @@
 package io.beanmapper.spring.converter;
 
 import io.beanmapper.BeanMapper;
-import io.beanmapper.core.BeanFieldMatch;
+import io.beanmapper.core.BeanPropertyMatch;
 import io.beanmapper.core.converter.BeanConverter;
 
 import org.springframework.core.convert.ConversionService;
@@ -32,7 +32,7 @@ public class ConversionServiceBeanConverter implements BeanConverter {
     }
 
     @Override
-    public Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
+    public Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanPropertyMatch beanFieldMatch) {
         return conversionService.convert(source, targetClass);
     }
 

--- a/src/main/java/io/beanmapper/spring/converter/IdToEntityBeanConverter.java
+++ b/src/main/java/io/beanmapper/spring/converter/IdToEntityBeanConverter.java
@@ -5,7 +5,7 @@ import java.io.Serializable;
 import javax.persistence.EntityNotFoundException;
 
 import io.beanmapper.BeanMapper;
-import io.beanmapper.core.BeanFieldMatch;
+import io.beanmapper.core.BeanPropertyMatch;
 import io.beanmapper.core.converter.BeanConverter;
 
 import org.springframework.context.ApplicationContext;
@@ -22,7 +22,7 @@ public class IdToEntityBeanConverter implements BeanConverter {
     }
     
     @Override
-    public Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
+    public Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanPropertyMatch beanFieldMatch) {
         if (source == null) {
             return null;
         }

--- a/src/main/java/io/beanmapper/spring/web/EntityFinder.java
+++ b/src/main/java/io/beanmapper/spring/web/EntityFinder.java
@@ -17,6 +17,17 @@ public interface EntityFinder {
      * @throws javax.persistence.EntityNotFoundException if the repository or the entity
      *         could not be found
      */
-    Object find(Long id, Class<?> entityClass) throws EntityNotFoundException;
+    <T> T find(Long id, Class<T> entityClass) throws EntityNotFoundException;
+
+    /**
+     * Returns the entity on the basis of the entity class and its ID bypassing the
+     * Hibernate cache
+     * @param entityClass the class of the entity
+     * @param id the ID of the entity
+     * @return the entity if found
+     * @throws javax.persistence.EntityNotFoundException if the repository or the entity
+     *         could not be found
+     */
+    <T> T findAndDetach(Long id, Class<T> entityClass) throws EntityNotFoundException;
 
 }

--- a/src/main/java/io/beanmapper/spring/web/MergePair.java
+++ b/src/main/java/io/beanmapper/spring/web/MergePair.java
@@ -23,7 +23,10 @@ public class MergePair<T> {
     }
 
     public void merge(Object source, Long id) {
-        T target = (T)findSource(id);
+        if (isMergePair()) {
+            setBeforeMerge(entityFinder.findAndDetach(id, targetEntityClass()));
+        }
+        T target = entityFinder.find(id, targetEntityClass());
         setAfterMerge(beanMapper.map(source, target));
     }
 
@@ -37,18 +40,6 @@ public class MergePair<T> {
 
     public Object result() {
         return isMergePair() ? this : getAfterMerge();
-    }
-
-    private void createBeforeMerge(Object source) {
-        setBeforeMerge(beanMapper.wrap().build().map(source, targetEntityClass()));
-    }
-
-    private Object findSource(Long id) {
-        Object entity = entityFinder.find(id, targetEntityClass());
-        if (isMergePair()) {
-            createBeforeMerge(entity);
-        }
-        return entity;
     }
 
     private boolean isMergePair() {

--- a/src/main/java/io/beanmapper/spring/web/MergedFormMethodArgumentResolver.java
+++ b/src/main/java/io/beanmapper/spring/web/MergedFormMethodArgumentResolver.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.persistence.EntityManager;
+
 import io.beanmapper.BeanMapper;
 import io.beanmapper.config.BeanMapperBuilder;
 import io.beanmapper.spring.Lazy;
@@ -44,8 +46,9 @@ public class MergedFormMethodArgumentResolver extends AbstractMessageConverterMe
 
     public MergedFormMethodArgumentResolver(List<HttpMessageConverter<?>> messageConverters,
                                             BeanMapper beanMapper, 
-                                            ApplicationContext applicationContext) {
-        this(messageConverters, beanMapper, new SpringDataEntityFinder(applicationContext));
+                                            ApplicationContext applicationContext,
+                                            EntityManager entityManager) {
+        this(messageConverters, beanMapper, new SpringDataEntityFinder(applicationContext, entityManager));
     }
 
     public MergedFormMethodArgumentResolver(List<HttpMessageConverter<?>> messageConverters,

--- a/src/main/java/io/beanmapper/spring/web/mockmvc/MockEntityFinder.java
+++ b/src/main/java/io/beanmapper/spring/web/mockmvc/MockEntityFinder.java
@@ -15,13 +15,19 @@ public class MockEntityFinder implements EntityFinder {
     private Map<Class<?>, CrudRepository<? extends Persistable, Long>> repositories = new HashMap<>();
 
     @Override
-    public Object find(Long id, Class<?> entityClass) throws EntityNotFoundException {
-        CrudRepository<? extends Persistable, Long> repository = repositories.get(entityClass);
+    public <T> T find(Long id, Class<T> entityClass) throws EntityNotFoundException {
+        CrudRepository<T, Long> repository = (CrudRepository<T, Long>)repositories.get(entityClass);
         if (repository == null) {
             throw new RuntimeException("No constructor found for " + entityClass.getSimpleName() +
                     ". Make sure to register the class in addConverters.registerExpectation");
         }
         return repository.findById(id).orElse(null);
+    }
+
+    @Override
+    public <T> T findAndDetach(Long id, Class<T> entityClass) throws EntityNotFoundException {
+        // Not supported, same as find
+        return find(id, entityClass);
     }
 
     public void addRepository(CrudRepository<? extends Persistable, Long> repository, Class<?> entityClass) {

--- a/src/main/java/io/beanmapper/spring/web/mockmvc/MockIdToEntityBeanConverter.java
+++ b/src/main/java/io/beanmapper/spring/web/mockmvc/MockIdToEntityBeanConverter.java
@@ -1,7 +1,7 @@
 package io.beanmapper.spring.web.mockmvc;
 
 import io.beanmapper.BeanMapper;
-import io.beanmapper.core.BeanFieldMatch;
+import io.beanmapper.core.BeanPropertyMatch;
 import io.beanmapper.core.converter.BeanConverter;
 
 import org.springframework.data.domain.Persistable;
@@ -19,7 +19,7 @@ public class MockIdToEntityBeanConverter implements BeanConverter {
     }
 
     @Override
-    public Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
+    public Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanPropertyMatch beanFieldMatch) {
         return repository.findById((Long)source).orElse(null);
     }
 

--- a/src/test/java/io/beanmapper/spring/web/EntityFinderTest.java
+++ b/src/test/java/io/beanmapper/spring/web/EntityFinderTest.java
@@ -27,13 +27,18 @@ public class EntityFinderTest extends AbstractSpringTest {
         EntityFinder entityFinder = new EntityFinder() {
 
             @Override
-            public Object find(Long id, Class<?> entityClass) throws EntityNotFoundException {
-                return personRepository.findById(id).orElse(null);
+            public <T> T find(Long id, Class<T> entityClass) throws EntityNotFoundException {
+                return (T)personRepository.findById(id).orElse(null);
+            }
+
+            @Override
+            public <T> T findAndDetach(Long id, Class<T> entityClass) throws EntityNotFoundException {
+                return find(id, entityClass);
             }
 
         };
 
-        Person foundPerson = (Person) entityFinder.find(person.getId(), Person.class);
+        Person foundPerson = entityFinder.find(person.getId(), Person.class);
         assertNotNull(foundPerson);
         assertEquals("Henk", foundPerson.getName());
     }

--- a/src/test/java/io/beanmapper/spring/web/PersonControllerTest.java
+++ b/src/test/java/io/beanmapper/spring/web/PersonControllerTest.java
@@ -76,7 +76,8 @@ public class PersonControllerTest extends AbstractSpringTest {
                 .setCustomArgumentResolvers(new MergedFormMethodArgumentResolver(
                         Arrays.<HttpMessageConverter<?>> asList(new StructuredJsonMessageConverter(converter)),
                         beanMapper,
-                        applicationContext))
+                        applicationContext,
+                        entityManager))
                 .setMessageConverters(converter)
                 .setConversionService(new FormattingConversionService())
                 .build();

--- a/src/test/java/io/beanmapper/spring/web/SpringDataEntityFinderTest.java
+++ b/src/test/java/io/beanmapper/spring/web/SpringDataEntityFinderTest.java
@@ -1,9 +1,12 @@
 package io.beanmapper.spring.web;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
+import javax.persistence.EntityManager;
 import javax.persistence.EntityNotFoundException;
+import javax.persistence.PersistenceContext;
 
 import io.beanmapper.BeanMapper;
 import io.beanmapper.spring.AbstractSpringTest;
@@ -13,11 +16,15 @@ import io.beanmapper.spring.model.PersonRepository;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.transaction.annotation.Transactional;
 
 public class SpringDataEntityFinderTest extends AbstractSpringTest {
 
     @Autowired
     private ApplicationContext applicationContext;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     @Autowired
     private PersonRepository personRepository;
@@ -29,21 +36,40 @@ public class SpringDataEntityFinderTest extends AbstractSpringTest {
         person.setCity("Lisse");
         person = personRepository.save(person);
 
-        EntityFinder entityFinder = new SpringDataEntityFinder(applicationContext);
+        EntityFinder entityFinder = new SpringDataEntityFinder(applicationContext, entityManager);
         Person foundPerson = (Person) entityFinder.find(person.getId(), Person.class);
         assertNotNull(foundPerson);
         assertEquals("Henk", foundPerson.getName());
     }
 
+    @Test
+    @Transactional
+    public void findAndDetach() {
+        Person person = new Person();
+        person.setName("Henk");
+        person.setCity("Lisse");
+        person = personRepository.save(person);
+
+        EntityFinder entityFinder = new SpringDataEntityFinder(applicationContext, entityManager);
+        Person person1 = entityFinder.find(person.getId(), Person.class);
+        Person person2 = entityFinder.find(person.getId(), Person.class);
+        assertEquals(person1, person2);
+
+        person1 = entityFinder.findAndDetach(person.getId(), Person.class);
+        person2 = entityFinder.find(person.getId(), Person.class);
+
+        assertNotEquals(person1, person2);
+    }
+
     @Test(expected = EntityNotFoundException.class)
     public void noRepository() {
-        EntityFinder entityFinder = new SpringDataEntityFinder(applicationContext);
+        EntityFinder entityFinder = new SpringDataEntityFinder(applicationContext, entityManager);
         entityFinder.find(42L, BeanMapper.class);
     }
 
     @Test(expected = EntityNotFoundException.class)
     public void entityNotFound() {
-        EntityFinder entityFinder = new SpringDataEntityFinder(applicationContext);
+        EntityFinder entityFinder = new SpringDataEntityFinder(applicationContext, entityManager);
         entityFinder.find(42L, Person.class);
     }
 

--- a/src/test/java/io/beanmapper/spring/web/mockmvc/fakedomain/FakeWebMvcConfig.java
+++ b/src/test/java/io/beanmapper/spring/web/mockmvc/fakedomain/FakeWebMvcConfig.java
@@ -3,6 +3,9 @@ package io.beanmapper.spring.web.mockmvc.fakedomain;
 import java.util.Collections;
 import java.util.List;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
 import io.beanmapper.BeanMapper;
 import io.beanmapper.spring.web.MergedFormMethodArgumentResolver;
 
@@ -47,6 +50,9 @@ public class FakeWebMvcConfig implements WebMvcConfigurer {
     @Autowired
     private ApplicationContext applicationContext;
 
+    @PersistenceContext
+    private EntityManager entityManager;
+
     @Override
     public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
         converters.add(mappingJackson2HttpMessageConverter());
@@ -63,7 +69,8 @@ public class FakeWebMvcConfig implements WebMvcConfigurer {
         argumentResolvers.add(new MergedFormMethodArgumentResolver(
                 Collections.singletonList(mappingJackson2HttpMessageConverter()),
                 beanMapper,
-                applicationContext
+                applicationContext,
+                entityManager
         ));
     }
 


### PR DESCRIPTION
When a MergePair is used, the beforeMerge is now retrieved and
immediately detached before the target is fetched. Take note that
this means that the original's proxies can no longer be resolved.
This restriction does not apply to the afterMerge instance, which
is still tied to its session as usual. The previous mechanism of
mapping the original (beforeMerge) to a variable using BeanMapper
has been scuttled.

EntityFinder has become a bit-more dev-friendly by taking note of
the classes it can return.

BeanConverters have been updated to the usage of BeanPropertyMatch
instead of BeanFieldMatch.