### PR TITLE
Add support for bean introspection via Spring BeanUtils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper-spring</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>42 Bean Mapper Spring Support</name>
     <description>Spring support for the Bean Mapper</description>
@@ -56,7 +56,7 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <beanmapper.version>3.0.0</beanmapper.version>
+        <beanmapper.version>3.0.2-SNAPSHOT</beanmapper.version>
         <commons.io.version>2.6</commons.io.version>
         <el.api.version>3.0.0</el.api.version>
         <el.impl.version>2.2</el.impl.version>

--- a/src/main/java/io/beanmapper/spring/config/BeanUtilsBasedBeanMatchStore.java
+++ b/src/main/java/io/beanmapper/spring/config/BeanUtilsBasedBeanMatchStore.java
@@ -1,0 +1,18 @@
+package io.beanmapper.spring.config;
+
+import io.beanmapper.config.CollectionHandlerStore;
+import io.beanmapper.core.BeanMatchStore;
+import io.beanmapper.core.inspector.PropertyAccessors;
+import io.beanmapper.core.unproxy.BeanUnproxy;
+
+public class BeanUtilsBasedBeanMatchStore extends BeanMatchStore {
+
+    public BeanUtilsBasedBeanMatchStore(CollectionHandlerStore collectionHandlerStore, BeanUnproxy beanUnproxy) {
+        super(collectionHandlerStore, beanUnproxy);
+    }
+
+    @Override
+    protected PropertyAccessors createPropertyAccessors() {
+        return new BeanUtilsBasedPropertyAccessors();
+    }
+}

--- a/src/main/java/io/beanmapper/spring/config/BeanUtilsBasedBeanMatchStore.java
+++ b/src/main/java/io/beanmapper/spring/config/BeanUtilsBasedBeanMatchStore.java
@@ -7,6 +7,7 @@ import io.beanmapper.core.unproxy.BeanUnproxy;
 
 public class BeanUtilsBasedBeanMatchStore extends BeanMatchStore {
 
+    @SuppressWarnings("WeakerAccess")
     public BeanUtilsBasedBeanMatchStore(CollectionHandlerStore collectionHandlerStore, BeanUnproxy beanUnproxy) {
         super(collectionHandlerStore, beanUnproxy);
     }

--- a/src/main/java/io/beanmapper/spring/config/BeanUtilsBasedConfigBuilder.java
+++ b/src/main/java/io/beanmapper/spring/config/BeanUtilsBasedConfigBuilder.java
@@ -3,6 +3,7 @@ package io.beanmapper.spring.config;
 import io.beanmapper.config.BeanMapperBuilder;
 import io.beanmapper.config.Configuration;
 
+@SuppressWarnings({"unused", "WeakerAccess"})
 public class BeanUtilsBasedConfigBuilder extends BeanMapperBuilder {
 
     public BeanUtilsBasedConfigBuilder() {

--- a/src/main/java/io/beanmapper/spring/config/BeanUtilsBasedConfigBuilder.java
+++ b/src/main/java/io/beanmapper/spring/config/BeanUtilsBasedConfigBuilder.java
@@ -1,0 +1,15 @@
+package io.beanmapper.spring.config;
+
+import io.beanmapper.config.BeanMapperBuilder;
+import io.beanmapper.config.Configuration;
+
+public class BeanUtilsBasedConfigBuilder extends BeanMapperBuilder {
+
+    public BeanUtilsBasedConfigBuilder() {
+        super(BeanUtilsBasedBeanMatchStore::new);
+    }
+
+    public BeanUtilsBasedConfigBuilder(Configuration configuration) {
+        super(configuration);
+    }
+}

--- a/src/main/java/io/beanmapper/spring/config/BeanUtilsBasedPropertyAccessors.java
+++ b/src/main/java/io/beanmapper/spring/config/BeanUtilsBasedPropertyAccessors.java
@@ -1,0 +1,14 @@
+package io.beanmapper.spring.config;
+
+import io.beanmapper.core.inspector.PropertyAccessors;
+import org.springframework.beans.BeanUtils;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+
+public class BeanUtilsBasedPropertyAccessors extends PropertyAccessors {
+    @Override
+    protected PropertyDescriptor[] extractPropertyDescriptors(Class<?> clazz) throws IntrospectionException {
+        return BeanUtils.getPropertyDescriptors(clazz);
+    }
+}

--- a/src/main/java/io/beanmapper/spring/config/BeanUtilsBasedPropertyAccessors.java
+++ b/src/main/java/io/beanmapper/spring/config/BeanUtilsBasedPropertyAccessors.java
@@ -3,12 +3,11 @@ package io.beanmapper.spring.config;
 import io.beanmapper.core.inspector.PropertyAccessors;
 import org.springframework.beans.BeanUtils;
 
-import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 
 public class BeanUtilsBasedPropertyAccessors extends PropertyAccessors {
     @Override
-    protected PropertyDescriptor[] extractPropertyDescriptors(Class<?> clazz) throws IntrospectionException {
+    protected PropertyDescriptor[] extractPropertyDescriptors(Class<?> clazz) {
         return BeanUtils.getPropertyDescriptors(clazz);
     }
 }

--- a/src/test/java/io/beanmapper/spring/config/BeanUtilsBasedConfigBuilderTest.java
+++ b/src/test/java/io/beanmapper/spring/config/BeanUtilsBasedConfigBuilderTest.java
@@ -16,6 +16,7 @@ public class BeanUtilsBasedConfigBuilderTest {
 
     }
 
+    @SuppressWarnings({"SameParameterValue", "unused"})
     static class Foo {
         private String strVal;
 
@@ -23,16 +24,17 @@ public class BeanUtilsBasedConfigBuilderTest {
             return strVal;
         }
 
-        public Foo setStrVal(String strVal) {
+        Foo setStrVal(String strVal) {
             this.strVal = strVal;
             return this;
         }
     }
 
+    @SuppressWarnings("unused")
     public static class Bar {
         private String strVal;
 
-        public String getStrVal() {
+        String getStrVal() {
             return strVal;
         }
 

--- a/src/test/java/io/beanmapper/spring/config/BeanUtilsBasedConfigBuilderTest.java
+++ b/src/test/java/io/beanmapper/spring/config/BeanUtilsBasedConfigBuilderTest.java
@@ -1,0 +1,46 @@
+package io.beanmapper.spring.config;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BeanUtilsBasedConfigBuilderTest {
+
+    @Test
+    public void testCopy() {
+
+        BeanUtilsBasedConfigBuilder builder = new BeanUtilsBasedConfigBuilder();
+        Bar bar = builder.build().map(new Foo().setStrVal("mee"), Bar.class);
+
+        assertEquals("mee", bar.getStrVal());
+
+    }
+
+    static class Foo {
+        private String strVal;
+
+        public String getStrVal() {
+            return strVal;
+        }
+
+        public Foo setStrVal(String strVal) {
+            this.strVal = strVal;
+            return this;
+        }
+    }
+
+    public static class Bar {
+        private String strVal;
+
+        public String getStrVal() {
+            return strVal;
+        }
+
+        public Bar setStrVal(String strVal) {
+            this.strVal = strVal;
+            return this;
+        }
+
+    }
+
+}

--- a/src/test/java/io/beanmapper/spring/config/BeanUtilsBasedPropertyAccessorsTest.java
+++ b/src/test/java/io/beanmapper/spring/config/BeanUtilsBasedPropertyAccessorsTest.java
@@ -1,0 +1,33 @@
+package io.beanmapper.spring.config;
+
+import io.beanmapper.core.inspector.PropertyAccessor;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class BeanUtilsBasedPropertyAccessorsTest {
+
+    @Test
+    public void testGetAll() {
+        List<PropertyAccessor> props = new BeanUtilsBasedPropertyAccessors().getAll(Foo.class);
+        assertEquals(1, props.size());
+        assertEquals("setStrVal", props.get(0).getWriteMethod().getName());
+    }
+
+    static class Foo {
+        private String strVal;
+
+        public String getStrVal() {
+            return strVal;
+        }
+
+        public Foo setStrVal(String strVal) {
+            this.strVal = strVal;
+            return this;
+        }
+    }
+
+}

--- a/src/test/java/io/beanmapper/spring/config/BeanUtilsBasedPropertyAccessorsTest.java
+++ b/src/test/java/io/beanmapper/spring/config/BeanUtilsBasedPropertyAccessorsTest.java
@@ -6,15 +6,15 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class BeanUtilsBasedPropertyAccessorsTest {
 
     @Test
     public void testGetAll() {
         List<PropertyAccessor> props = new BeanUtilsBasedPropertyAccessors().getAll(Foo.class);
-        assertEquals(1, props.size());
-        assertEquals("setStrVal", props.get(0).getWriteMethod().getName());
+        //noinspection OptionalGetWithoutIsPresent - failure is expected if none found
+        PropertyAccessor strValProperty = props.stream().filter(prop -> prop.getName().equals("strVal")).findFirst().get();
+        assertEquals("setStrVal", strValProperty.getWriteMethod().getName());
     }
 
     static class Foo {


### PR DESCRIPTION
Introspection via BeanUtils allows for proper support of beans with fluid setters (i.e. returning "this" and allowing for chaining setters invocations)